### PR TITLE
fix: "char" → "chr"

### DIFF
--- a/src/util/camelize.js
+++ b/src/util/camelize.js
@@ -1,5 +1,5 @@
 var rHyphen = /-(.)/g;
 
 module.exports = function camelize(string) {
-  return string.replace(rHyphen, (_, char) => char.toUpperCase())
+  return string.replace(rHyphen, (_, chr) => chr.toUpperCase())
 }


### PR DESCRIPTION
"char" is reserved word. I have compile errors, when trying compile with google-closure-compiler.

    .tmp/app.js:15129: ERROR - Parse error. identifier is a reserved word
      return string.replace(rHyphen, function (_, char) {
    ^

    .tmp/app.js:15130: ERROR - Parse error. identifier is a reserved word
        return char.toUpperCase();
    ^